### PR TITLE
BUG FIX: average rating on products with ratings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ media
 *.py[cod]
 *$py.class
 
+# SQL
+.sql
+
 # C extensions
 *.so
 

--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -59,11 +59,16 @@ class Product(SafeDeleteModel):
         """
         ratings = ProductRating.objects.filter(product=self)
         total_rating = 0
+
         for rating in ratings:
             total_rating += rating.rating
 
-        avg = total_rating / len(ratings)
-        return avg
+        try:
+            avg = total_rating / len(ratings)
+            return avg
+        except ZeroDivisionError:
+            return "nah"
+
 
     class Meta:
         verbose_name = ("product")

--- a/test.sql
+++ b/test.sql
@@ -1,0 +1,1 @@
+SELECT * FROM bangazonapi_product WHERE id=50

--- a/test.sql
+++ b/test.sql
@@ -1,1 +1,0 @@
-SELECT * FROM bangazonapi_product WHERE id=50


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Product MODEL custom property `average_rating` 

## Requests / Responses

**Request**

GET `http://localhost:8000/products` to get all products

**Response**

HTTP/1.1 200 OK

```json
{
        "id": 50,
        "name": "Escalade EXT",
        "price": 926.92,
        "number_sold": 2,
        "description": "2008 Cadillac",
        "quantity": 2,
        "created_date": "2019-02-01",
        "location": "Lokavec",
        "image_path": null,
        "average_rating": 3.25 ~~~
        }
```

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Open PostMan workspace
- GET http://localhost:8000/products
- Look for product_id 50. 50 is currently the only product with a rating attached.

## Related Issues

- Fixes #15 