### PR TITLE
FIX: duplicate 'lineitems' response fixed

### DIFF
--- a/bangazonapi/views/cart.py
+++ b/bangazonapi/views/cart.py
@@ -75,9 +75,9 @@ class Cart(ViewSet):
         @apiSuccess (200) {Object} payment_type Payment id use to complete order
         @apiSuccess (200) {String} customer URI for customer
         @apiSuccess (200) {Number} size Number of items in cart
-        @apiSuccess (200) {Object[]} line_items Line items in cart
-        @apiSuccess (200) {Number} line_items.id Line item id
-        @apiSuccess (200) {Object} line_items.product Product in cart
+        @apiSuccess (200) {Object[]} lineitems Line items in cart
+        @apiSuccess (200) {Number} lineitems.id Line item id
+        @apiSuccess (200) {Object} lineitems.product Product in cart
         @apiSuccessExample {json} Success
             {
                 "id": 2,

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -185,7 +185,6 @@ class Profile(ViewSet):
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
                                                 'request': request}).data
-                cart["order"]["lineitems"] = lineitems.data
                 cart["order"]["size"] = len(lineitems.data)
 
             except Order.DoesNotExist as ex:

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -115,8 +115,8 @@ class Profile(ViewSet):
             try:
                 open_order = Order.objects.get(
                     customer=current_user, payment_type=None)
-                line_items = OrderProduct.objects.filter(order=open_order)
-                line_items.delete()
+                lineitems = OrderProduct.objects.filter(order=open_order)
+                lineitems.delete()
                 open_order.delete()
             except Order.DoesNotExist as ex:
                 return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
@@ -139,9 +139,9 @@ class Profile(ViewSet):
             @apiSuccess (200) {Object} payment_type Payment Id used to complete order
             @apiSuccess (200) {String} customer URI for customer
             @apiSuccess (200) {Number} size Number of items in cart
-            @apiSuccess (200) {Object[]} line_items Line items in cart
-            @apiSuccess (200) {Number} line_items.id Line item id
-            @apiSuccess (200) {Object} line_items.product Product in cart
+            @apiSuccess (200) {Object[]} lineitems Line items in cart
+            @apiSuccess (200) {Number} lineitems.id Line item id
+            @apiSuccess (200) {Object} lineitems.product Product in cart
             @apiSuccessExample {json} Success
                 {
                     "id": 2,
@@ -149,7 +149,7 @@ class Profile(ViewSet):
                     "created_date": "2019-04-12",
                     "payment_type": null,
                     "customer": "http://localhost:8000/customers/7",
-                    "line_items": [
+                    "lineitems": [
                         {
                             "id": 4,
                             "product": {
@@ -178,15 +178,15 @@ class Profile(ViewSet):
             try:
                 open_order = Order.objects.get(
                     customer=current_user, payment_type=None)
-                line_items = OrderProduct.objects.filter(order=open_order)
-                line_items = LineItemSerializer(
-                    line_items, many=True, context={'request': request})
+                lineitems = OrderProduct.objects.filter(order=open_order)
+                lineitems = LineItemSerializer(
+                    lineitems, many=True, context={'request': request})
 
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
                                                 'request': request}).data
-                cart["order"]["line_items"] = line_items.data
-                cart["order"]["size"] = len(line_items.data)
+                cart["order"]["lineitems"] = lineitems.data
+                cart["order"]["size"] = len(lineitems.data)
 
             except Order.DoesNotExist as ex:
                 return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Cart views, changed line_items to lineitems
- Profile views, change line_items to lineitems

## Requests / Responses

**Request**

GET `http://localhost:8000/profile/cart` gets the current users cart

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 2,
    "url": "http://localhost:8000/orders/2",
    "created_date": "2019-04-12",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/7",
    "lineitems": [
        {
            "id": 4,
            "product": {
                "id": 52,
                "name": "900",
                "price": 1296.98,
                "number_sold": 0,
                "description": "1987 Saab",
                "quantity": 2,
                "created_date": "2019-03-19",
                "location": "Vratsa",
                "image_path": null,
                "average_rating": "nah"
            }
        },
        {
            "id": 5,
            "product": {
                "id": 33,
                "name": "Stratus",
                "price": 1199.91,
                "number_sold": 0,
                "description": "2001 Dodge",
                "quantity": 1,
                "created_date": "2019-04-06",
                "location": "Tianning",
                "image_path": null,
                "average_rating": "nah"
            }
        },
        {
            "id": 6,
            "product": {
                "id": 71,
                "name": "Sebring",
                "price": 1045.66,
                "number_sold": 0,
                "description": "1999 Chrysler",
                "quantity": 4,
                "created_date": "2019-05-18",
                "location": "Namibe",
                "image_path": null,
                "average_rating": "nah"
            }
        }
    ],
    "size": 3
}
```

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Open PostMan workspace
- [ ] Refer to Request/Response section


## Related Issues

- Fixes #24 