### PR TITLE
FIX: All payment types returned on GET/paymenttypes

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -9,7 +9,6 @@ from bangazonapi.models import Payment, Customer
 
 class PaymentSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for Payment
-
     Arguments:
         serializers
     """
@@ -20,34 +19,29 @@ class PaymentSerializer(serializers.HyperlinkedModelSerializer):
             lookup_field='id'
         )
         fields = ('id', 'url', 'merchant_name', 'account_number',
-                  'expiration_date', 'create_date')
+                  'expiration_date', 'create_date', 'customer_id')
 
 
 class Payments(ViewSet):
-
     def create(self, request):
         """Handle POST operations
-
         Returns:
             Response -- JSON serialized payment instance
         """
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()
-
         serializer = PaymentSerializer(
             new_payment, context={'request': request})
-
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def retrieve(self, request, pk=None):
         """Handle GET requests for single payment type
-
         Returns:
             Response -- JSON serialized payment_type instance
         """
@@ -61,19 +55,15 @@ class Payments(ViewSet):
 
     def destroy(self, request, pk=None):
         """Handle DELETE requests for a single payment type
-
         Returns:
             Response -- 200, 404, or 500 status code
         """
         try:
             payment = Payment.objects.get(pk=pk)
             payment.delete()
-
             return Response({}, status=status.HTTP_204_NO_CONTENT)
-
         except Payment.DoesNotExist as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
-
         except Exception as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
@@ -81,11 +71,11 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
+        customer = Customer.objects.get(user=request.auth.user)
+        customer_id = customer.id
 
         if customer_id is not None:
             payment_types = payment_types.filter(customer__id=customer_id)
-
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})
         return Response(serializer.data)

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -1,4 +1,6 @@
 """View module for handling requests about customer profiles"""
+from django.db.models import fields
+from bangazonapi.models.payment import Payment
 import datetime
 from django.http import HttpResponseServerError
 from django.contrib.auth.models import User
@@ -362,6 +364,12 @@ class RecommenderSerializer(serializers.ModelSerializer):
         model = Recommendation
         fields = ('product', 'customer',)
 
+class PaymentSerializer(serializers.ModelSerializer):
+
+    customer = CustomerSerializer()
+    class Meta:
+        model = Payment
+        fields = ('merchant_name', 'customer', 'expiration_date' )
 
 class ProfileSerializer(serializers.ModelSerializer):
     """JSON serializer for customer profile
@@ -371,6 +379,7 @@ class ProfileSerializer(serializers.ModelSerializer):
     """
     user = UserSerializer(many=False)
     recommends = RecommenderSerializer(many=True)
+    payment_types = PaymentSerializer(many=True)
 
     class Meta:
         model = Customer


### PR DESCRIPTION
## Changes

- Profile view
> Added payment serializer to return the current users payment types (not all information)

- PaymentTypes 
> Changed LIST to get customer by auth.user, to return the payment types of the current user.

## Requests / Responses

**Request**

GET `/profile`

**Response**

```json
{
    "id": 5,
    "url": "http://localhost:8000/customers/5",
    "user": {
        "first_name": "Joe",
        "last_name": "Shepherd",
        "email": "joe@joeshepherd.com"
    },
    "phone_number": "555-1212",
    "address": "100 Endless Way",
    "payment_types": [
        {
            "merchant_name": "Visa",
            "customer": {
                "id": 5,
                "user": {
                    "first_name": "Joe",
                    "last_name": "Shepherd",
                    "email": "joe@joeshepherd.com"
                }
            },
            "expiration_date": "2020-01-01"
        }
    ],
    "recommends": []
}
```
**Request**

GET `/paymenttypes`

**Response**

```json
[
    {
        "id": 1,
        "url": "http://localhost:8000/paymenttypes/1",
        "merchant_name": "Visa",
        "account_number": "24ijio68948fj8439",
        "expiration_date": "2020-01-01",
        "create_date": "2019-11-11",
        "customer_id": 5
    }
]
```

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Open PostMan
- [ ] GET http://localhost:8000/paymenttypes
- [ ] Refer to /paymenttypes response
- [ ] GET http://localhost:8000/profile
- [ ] Refer to /profile response


## Related Issues

- Fixes #18 
- Fixes #19 