### PR TITLE
Dl increase maximum price

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -15,7 +15,7 @@ class Product(SafeDeleteModel):
     customer = models.ForeignKey(
         Customer, on_delete=models.DO_NOTHING, related_name='products')
     price = models.FloatField(
-        validators=[MinValueValidator(0.00), MaxValueValidator(10000.00)],)
+        validators=[MinValueValidator(0.00), MaxValueValidator(17500.00)],)
     description = models.CharField(max_length=255,)
     quantity = models.IntegerField(validators=[MinValueValidator(0)],)
     created_date = models.DateField(auto_now_add=True)

--- a/tests/product.py
+++ b/tests/product.py
@@ -34,7 +34,7 @@ class ProductTests(APITestCase):
         url = "/products"
         data = {
             "name": "Kite",
-            "price": 14.99,
+            "price": 17501.00,
             "quantity": 60,
             "description": "It flies high",
             "category_id": 1,
@@ -46,7 +46,7 @@ class ProductTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(json_response["name"], "Kite")
-        self.assertEqual(json_response["price"], 14.99)
+        self.assertEqual(json_response["price"], 17501.00)
         self.assertEqual(json_response["quantity"], 60)
         self.assertEqual(json_response["description"], "It flies high")
         self.assertEqual(json_response["location"], "Pittsburgh")


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Product class Model, price key, increased the MaxValueValidator attribute to 17500.00

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

POST `/products` Creates a new product

```json
{
    "name": "Kite",
    "price": 17501.0,
    "number_sold": 0,
    "description": "It flies high",
    "quantity": 60,
    "created_date": "2021-09-03",
    "location": "Pittsburgh",
    "image_path": "http://localhost:8000/media/products/None-Kite_aovf2Dp.jpeg",
    "average_rating": "nah"
}
```

**Response**

HTTP/1.1 201 CREATED

```json
{
    "id": 102,
    "name": "Kite",
    "price": 17501.0,
    "number_sold": 0,
    "description": "It flies high",
    "quantity": 60,
    "created_date": "2021-09-03",
    "location": "Pittsburgh",
    "image_path": "http://localhost:8000/media/products/None-Kite_aovf2Dp.jpeg",
    "average_rating": "nah"
}
```

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Open PostMan to correct workspace
- [ ] POST `http://localhost:8000/products`
- [ ] BODY 
```json
{
    "name": "Kite",
    "price": 17501.0,
    "number_sold": 0,
    "description": "It flies high",
    "quantity": 60,
    "created_date": "2021-09-03",
    "location": "Pittsburgh",
    "image_path": "Kite.jpg",
    "average_rating": "nah"
}
```
- [ ] Response should match `Response` section in this PR


## Related Issues

- Fixes #16 